### PR TITLE
TransformerFunc returns when input is closed

### DIFF
--- a/transformer.go
+++ b/transformer.go
@@ -13,7 +13,10 @@ func TransformerFunc[Input, Output any](ctx context.Context, input <-chan Input,
 			select {
 			case <-ctx.Done():
 				return
-			case val := <-input:
+			case val, ok := <-input:
+				if !ok {
+					return
+				}
 				out <- f(ctx, val)
 			}
 		}


### PR DESCRIPTION
The goroutine started by TransformerFunc reads from the `input` channel even if it was closed, never returning and never closing the `out` channel.