### PR TITLE
fix: remove unnecessary ctx.Err() check

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -47,9 +47,6 @@ func bridgeInputStream[Input any](ctx context.Context, inputs <-chan Input, out 
 			if !ok {
 				return
 			}
-			if ctx.Err() != nil {
-				return
-			}
 			out <- val
 		}
 	}

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -119,21 +119,4 @@ func TestBridge(t *testing.T) {
 			t.Errorf("Expected output to be closed, but was not")
 		}
 	})
-
-	//t.Run("test bridgeInputStream ctx.Err()", func(t *testing.T) {
-	//	ctx, cancel := context.WithCancel(context.Background())
-	//	intChan := make(chan int)
-	//	outChan := make(chan int)
-	//	go func() {
-	//		intChan <- 1
-	//		cancel()
-	//	}()
-	//	bridgeInputStream(ctx, intChan, outChan)
-	//	select {
-	//	case <-outChan:
-	//		t.Fatal("Expected output channel to be empty")
-	//	default:
-	//		// channel was empty, test passed.
-	//	}
-	//})
 }

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -119,4 +119,21 @@ func TestBridge(t *testing.T) {
 			t.Errorf("Expected output to be closed, but was not")
 		}
 	})
+
+	//t.Run("test bridgeInputStream ctx.Err()", func(t *testing.T) {
+	//	ctx, cancel := context.WithCancel(context.Background())
+	//	intChan := make(chan int)
+	//	outChan := make(chan int)
+	//	go func() {
+	//		intChan <- 1
+	//		cancel()
+	//	}()
+	//	bridgeInputStream(ctx, intChan, outChan)
+	//	select {
+	//	case <-outChan:
+	//		t.Fatal("Expected output channel to be empty")
+	//	default:
+	//		// channel was empty, test passed.
+	//	}
+	//})
 }


### PR DESCRIPTION
`<-ctx.Done()` serves the same purpose and will catch a cancellation event more immediately